### PR TITLE
docs: establish BriskFlow identity after DataSys transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,66 +2,66 @@ blank_issues_enabled: false
 contact_links:
   # Common Templates
   - name: "Bug Report"
-    url: "/intellistream/sageFlow/issues/new?template=bug_report.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=bug_report.md"
     about: "Report a bug or unexpected behavior"
 
   - name: "Feature Request"
-    url: "/intellistream/sageFlow/issues/new?template=feature_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=feature_request.md"
     about: "Suggest a new feature or improvement"
 
   - name: "Documentation Request"
-    url: "/intellistream/sageFlow/issues/new?template=documentation_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=documentation_request.md"
     about: "Request improvements or additions to documentation"
 
   - name: "Question"
-    url: "/intellistream/sageFlow/issues/new?template=question.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=question.md"
     about: "Ask a question about the project"
 
   - name: "Enhancement Request"
-    url: "/intellistream/sageFlow/issues/new?template=enhancement_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=enhancement_request.md"
     about: "Request an improvement or optimization"
 
   - name: "Performance Issue"
-    url: "/intellistream/sageFlow/issues/new?template=performance_issue.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=performance_issue.md"
     about: "Report a performance issue or inefficiency"
 
   - name: "Security Vulnerability"
-    url: "/intellistream/sageFlow/issues/new?template=security_vulnerability.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=security_vulnerability.md"
     about: "Report a security vulnerability (confidential)"
 
   - name: "Refactor Request"
-    url: "/intellistream/sageFlow/issues/new?template=refactor_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=refactor_request.md"
     about: "Suggest a refactoring to improve code quality"
 
   - name: "Task"
-    url: "/intellistream/sageFlow/issues/new?template=task.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=task.md"
     about: "Log a general task or maintenance activity"
 
   # Research-Specific Templates
   - name: "Paper Discussion"
-    url: "/intellistream/sageFlow/issues/new?template=paper_discussion.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=paper_discussion.md"
     about: "Discuss insights, critiques, or questions about a research paper"
 
   - name: "Experiment Tracking"
-    url: "/intellistream/sageFlow/issues/new?template=experiment_tracking.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=experiment_tracking.md"
     about: "Log the setup, execution, and results of an experiment"
 
   - name: "Dataset Request"
-    url: "/intellistream/sageFlow/issues/new?template=dataset_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=dataset_request.md"
     about: "Request a dataset for experiments or analysis"
 
   - name: "Research Collaboration Request"
-    url: "/intellistream/sageFlow/issues/new?template=research_collaboration_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=research_collaboration_request.md"
     about: "Request collaboration on a research topic, project, or experiment"
 
   - name: "Research Paper Progress"
-    url: "/intellistream/sageFlow/issues/new?template=research_paper_progress.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=research_paper_progress.md"
     about: "Log and track the progress of an ongoing research paper"
 
   - name: "Literature Review Request"
-    url: "/intellistream/sageFlow/issues/new?template=literature_review_request.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=literature_review_request.md"
     about: "Request a literature review on a specific research topic"
 
   - name: "Algorithm Exploration"
-    url: "/intellistream/sageFlow/issues/new?template=algorithm_exploration.md"
+    url: "/DataSysResearch/BriskFlow/issues/new?template=algorithm_exploration.md"
     about: "Explore and document findings on a new algorithm or method"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-## sageFlow
+# BriskFlow
 
-`sageFlow` is a cutting-edge, vector-native stream processing engine designed specifically to maintain and materialize semantic state snapshots for real-time, LLM-based generation tasks. The engine offers a declarative API to compose stateful vector operations within temporal windows, enabling fast and efficient updates to semantic context for dynamically changing datasets.
+BriskFlow is a vector-native stream processing engine for continuously evolving data. It provides a declarative Stream DAG, multicore execution, window-owned state, and indexed operators for similarity joins, TopK, filtering, aggregation, and snapshot materialization.
+
+BriskFlow is the DataSys runtime behind the join-backed semantic windows demonstrated by **BriskSnapshot** at ICPP 2026. BriskSnapshot combines this engine with orchestration and application-facing contracts; BriskFlow remains the framework-neutral data-system core.
+
+> **Compatibility note**
+>
+> The C++ namespace, `SAGEFLOW_*` build/runtime switches, Python import surface, and `isage-flow` package name are retained temporarily for compatibility. New documentation and repository references use **BriskFlow**. Their eventual deprecation will be handled as a separately versioned API migration.
 
 ## Features
 
--   **Vector-Native Stream Processing**: At its core, sageFlow is built to handle high-dimensional vector streams efficiently.
+-   **Vector-Native Stream Processing**: At its core, BriskFlow is built to handle high-dimensional vector streams efficiently.
 -   **Declarative API**: Easily compose complex, stateful vector operations such as `TopK`, `Filter`, and `Join` within defined temporal windows.
 -   **Incremental Low-Latency Updates**: Optimized for incremental computations, ensuring semantic states are updated with minimal delay.
 -   **Optimized Three-Phase Pipeline**: Abstracts stream processing into three distinct phases—ingestion, state materialization, and snapshot exposure—unlocking significant optimization opportunities.
@@ -26,9 +32,9 @@ For repository governance, release coordination, and external communication, use
 
 ## Setup
 
-To setup `sageFlow` and it's dependencies, begin by making sure that you have `docker` installed, or any **Linux** release version that contains `apt`, such as `Ubuntu` or `Debian`
+To set up BriskFlow and its dependencies, first make sure that `docker` is installed, or use a **Linux** distribution with `apt`, such as Ubuntu or Debian.
 
-We suggest first begin with `docker` before you are familiar with `sageFlow`.
+We recommend starting with Docker while becoming familiar with BriskFlow.
 
 ### Quick Installation (Ubuntu/Debian)
 
@@ -72,7 +78,7 @@ cd <PATH_TO_REPO>/setup
 
 check the dependencies in <PATH_TO_REPO>/setup/Dockerfile, and build your env
 
-## sageFlow: examples
+## BriskFlow examples
 
 run the following commands to generate examples
 
@@ -86,3 +92,13 @@ You can run the examples with:
 ```
 ./build/bin/itopk
 ```
+
+## Ecosystem
+
+- [DataSys](https://datasys.sage.org.ai/) owns and maintains the framework-neutral BriskFlow engine.
+- [SAGE](https://sage.org.ai/) may consume BriskFlow through a thin integration adapter for application and workflow orchestration.
+- [BriskSnapshot](https://datasys.sage.org.ai/achievements.html) is the ICPP 2026 demonstration built on join-backed semantic windows.
+
+## Canonical repository
+
+The canonical source, issue tracker, and contribution history are at [DataSysResearch/BriskFlow](https://github.com/DataSysResearch/BriskFlow).

--- a/SUBMODULE.md
+++ b/SUBMODULE.md
@@ -1,11 +1,15 @@
-# Git Submodule: sageFlow
+# SAGE integration compatibility
+
+BriskFlow is now the framework-neutral DataSys core. This file documents the
+legacy SAGE submodule integration; SAGE should keep a thin adapter and pin a
+released BriskFlow version.
 
 ⚠️ **This directory is a Git submodule** - it's a separate repository!
 
 ## Repository Information
 
 - **Name:** packages/sage-middleware/src/sage/middleware/components/sage_flow/sageFlow
-- **Repository:** https://github.com/intellistream/sageFlow.git
+- **Core repository:** https://github.com/DataSysResearch/BriskFlow.git
 - **Branch:** main-dev
 - **Path:** `packages/sage-middleware/src/sage/middleware/components/sage_flow/sageFlow`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "isage-flow"
 version = "0.1.3.1"
-description = "SageFlow - Vector-native stream processing engine for incremental semantic state snapshots"
+description = "BriskFlow - Vector-native stream processing engine for join-backed semantic windows"
 authors = [
     { name = "IntelliStream Team" }
 ]
@@ -42,10 +42,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/intellistream/sageFlow"
-Documentation = "https://intellistream.github.io/SAGE/"
-Repository = "https://github.com/intellistream/sageFlow"
-Issues = "https://github.com/intellistream/sageFlow/issues"
+Homepage = "https://datasys.sage.org.ai/"
+Documentation = "https://github.com/DataSysResearch/BriskFlow/tree/main/docs"
+Repository = "https://github.com/DataSysResearch/BriskFlow"
+Issues = "https://github.com/DataSysResearch/BriskFlow/issues"
 
 [tool.scikit-build]
 cmake.version = ">=3.15"


### PR DESCRIPTION
## Summary
- rename the public project identity from sageFlow to BriskFlow
- describe BriskSnapshot as the ICPP 2026 demo built on the broader engine
- update canonical repository and community links for DataSys
- preserve source-level and package compatibility names for downstream users

## Validation
- git diff --check
- pyproject.toml parses successfully
- canonical identity/link assertions pass

## Compatibility
The C++ namespace, build flags, Python import path, and `isage-flow` package name remain unchanged in this PR.