### PR TITLE
docs: repair migration references and evidence wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 BriskFlow is a vector-native stream processing engine for continuously evolving data. It provides a declarative Stream DAG, multicore execution, window-owned state, and indexed operators for similarity joins, TopK, filtering, aggregation, and snapshot materialization.
 
-BriskFlow is the DataSys runtime behind the join-backed semantic windows demonstrated by **BriskSnapshot** at ICPP 2026. BriskSnapshot combines this engine with orchestration and application-facing contracts; BriskFlow remains the framework-neutral data-system core.
+BriskFlow is the DataSys runtime behind the join-backed semantic windows demonstrated by **BriskSnapshot**. The authors report that BriskSnapshot has been accepted to the ICPP 2026 demo track; a public conference program or proceedings record is not yet available. BriskSnapshot combines this engine with orchestration and application-facing contracts; BriskFlow remains the framework-neutral data-system core.
 
 > **Compatibility note**
 >
@@ -97,7 +97,7 @@ You can run the examples with:
 
 - [DataSys](https://datasys.sage.org.ai/) owns and maintains the framework-neutral BriskFlow engine.
 - [SAGE](https://sage.org.ai/) may consume BriskFlow through a thin integration adapter for application and workflow orchestration.
-- [BriskSnapshot](https://datasys.sage.org.ai/achievements.html) is the ICPP 2026 demonstration built on join-backed semantic windows.
+- [BriskSnapshot](https://datasys.sage.org.ai/achievements.html) is the join-backed semantic windows demonstration built on BriskFlow. Its authors report acceptance to the ICPP 2026 demo track; the public conference record is pending.
 
 ## Canonical repository
 

--- a/include/execution/connection_strategy.h
+++ b/include/execution/connection_strategy.h
@@ -102,7 +102,7 @@ public:
 private:
   // SPSC 环形缓冲队列容量
   // TODO: 根据流速或上游数据量动态调整队列大小
-  // Issue URL: https://github.com/intellistream/sageFlow/issues/81
+  // Issue URL: https://github.com/DataSysResearch/BriskFlow/issues/81
   //       可考虑的方案：
   //       1. 基于背压(backpressure)的动态扩容
   //       2. 根据上游算子的预估输出量在 buildGraph 时计算合适容量

--- a/src/execution/centroid_partitioner.cpp
+++ b/src/execution/centroid_partitioner.cpp
@@ -188,7 +188,7 @@ size_t CentroidPartitioner::partition(const Response& data, size_t num_channels)
   // 未训练且未启用冷启动时：所有数据路由到 subtask 0
   // 这确保了 ClusteredJoin 的正确性，但会退化为单线程模式
   // TODO: 实现在线训练或使用 LSH 分区来支持并行
-  // Issue URL: https://github.com/intellistream/sageFlow/issues/95
+  // Issue URL: https://github.com/DataSysResearch/BriskFlow/issues/95
   if (!trained_.load()) {
     return 0;
   }

--- a/src/operator/join_operator.cpp
+++ b/src/operator/join_operator.cpp
@@ -1647,7 +1647,7 @@ std::unique_ptr<IPartitioner> JoinOperator::getPreferredPartitioner(
             case JoinAlgorithm::VSJOIN: {
                 // 临时方案：VSJoin 先复用 ClusteredJoin 的 CentroidPartitioner 以获得多播能力（multicast_k）。
                 // TODO(vsjoin): 实现 LSHPartitionerAdapter 的多播接口（supportsMulticast/partitionMulti + k），
-                // Issue URL: https://github.com/intellistream/sageFlow/issues/102
+                // Issue URL: https://github.com/DataSysResearch/BriskFlow/issues/102
                 // 再切回 LSH 分区。
                 CentroidPartitioner::Config cp_config;
                 cp_config.num_partitions = (num_partitions > 0)

--- a/src/operator/utils/join_strategy_factory.cpp
+++ b/src/operator/utils/join_strategy_factory.cpp
@@ -159,7 +159,7 @@ JoinStrategyFactory::StrategyComponents JoinStrategyFactory::create(
             // VSJoin 需要 VectorSpacePartitioner
             components.vector_partitioner = createVectorSpacePartitioner(config);
             // TODO: 创建其他 VSJoin 组件（coordinator, async_gen, verifier）
-            // Issue URL: https://github.com/intellistream/sageFlow/issues/79
+            // Issue URL: https://github.com/DataSysResearch/BriskFlow/issues/79
             break;
         }
         case JoinAlgorithm::S3J:

--- a/test/IntegrationTest/test_vsjoin_integration.cpp
+++ b/test/IntegrationTest/test_vsjoin_integration.cpp
@@ -9,8 +9,8 @@
  * - VSJoinMethod 类位于: include/operator/join_operator_methods/vsjoin_method.h
  * 
  * TODO: 使用 VSJoinMethod 和 JoinStrategyFactory 重写此测试
- Issue URL: https://github.com/intellistream/sageFlow/issues/90
- * Issue: https://github.com/intellistream/sageFlow/issues/85
+ Issue URL: https://github.com/DataSysResearch/BriskFlow/issues/90
+ * Issue: https://github.com/DataSysResearch/BriskFlow/issues/85
  */
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Repairs migrated issue deep links and qualifies the BriskSnapshot acceptance statement without changing compatibility namespaces.